### PR TITLE
Ajax for autocomplete widgets

### DIFF
--- a/database/templates/database/creation_form.html
+++ b/database/templates/database/creation_form.html
@@ -86,7 +86,204 @@
         $('#form_set').append($('#empty_form').html().replace(/__prefix__/g, form_idx));
         $('#id_form-TOTAL_FORMS').val(parseInt(form_idx) + 1);
     });
+    document.addEventListener('DOMContentLoaded', function() {
+      // Listen for add Genre Type
+      var addButton = document.getElementById('add-type-button');
+      addButton.addEventListener('click', function(event) {
+        event.preventDefault(); // Prevent form submission
+        var newTypeName = document.getElementById('add-type-input').value;
+        // Send AJAX request to the server
+        var xhr = new XMLHttpRequest();
+        xhr.open('POST', "{% url 'create-type-function' %}", true);
+        xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+        xhr.setRequestHeader('X-CSRFToken', '{{ csrf_token }}');
+        xhr.onreadystatechange = function() {
+          if (xhr.readyState === XMLHttpRequest.DONE) {
+            if (xhr.status === 200) {
+              console.log("New type created successfully!");
+              document.getElementById('add-type-input').value = '';
+            } else {
+              console.log("Error creating new type:", xhr.responseText);
+            }
+          }
+        };
+        xhr.send('typeName=' + encodeURIComponent(newTypeName));
+        xhr.send('newObjectForAutocomplete=' + encodeURIComponent('True'));
+      });
+    });
+
+    document.addEventListener('DOMContentLoaded', function() {
+      // Listen for add Genre Type
+      var addButton = document.getElementById('add-style-button');
+      addButton.addEventListener('click', function(event) {
+        event.preventDefault();
+        var newStyleName = document.getElementById('add-style-input').value;
+        // Send AJAX request to the server
+        var xhr = new XMLHttpRequest();
+        xhr.open('POST', "{% url 'create-style-function' %}", true);
+        xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+        xhr.setRequestHeader('X-CSRFToken', '{{ csrf_token }}');
+        xhr.onreadystatechange = function() {
+          if (xhr.readyState === XMLHttpRequest.DONE) {
+            if (xhr.status === 200) {
+              console.log("New style created successfully!");
+              document.getElementById('add-style-input').value = '';
+            } else {
+              console.log("Error creating new style:", xhr.responseText);
+            }
+          }
+        };
+        xhr.send('styleName=' + encodeURIComponent(newStyleName));
+        xhr.send('newObjectForAutocomplete=' + encodeURIComponent('True'));
+      });
+    });
+
+    document.addEventListener('DOMContentLoaded', function() {
+      // Listen for add instrument
+      var addButton = document.getElementById('add-instrument-button');
+      addButton.addEventListener('click', function(event) {
+        event.preventDefault();
+        var newInstrumentName = document.getElementById('add-instrument-input').value;
+        // Send AJAX request to the server
+        var xhr = new XMLHttpRequest();
+        xhr.open('POST', "{% url 'create-instrument-function' %}", true);
+        xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+        xhr.setRequestHeader('X-CSRFToken', '{{ csrf_token }}');
+        xhr.onreadystatechange = function() {
+          if (xhr.readyState === XMLHttpRequest.DONE) {
+            if (xhr.status === 200) {
+              console.log("New instrument created successfully!");
+              document.getElementById('add-instrument-input').value = '';
+            } else {
+              console.log("Error creating new instrument:", xhr.responseText);
+            }
+          }
+        };
+        xhr.send('instrumentName=' + encodeURIComponent(newInstrumentName));
+        xhr.send('newObjectForAutocomplete=' + encodeURIComponent('True'));
+      });
+    });
+
+    document.addEventListener('DOMContentLoaded', function() {
+      // Listen for add Location
+      var addButton = document.querySelectorAll('.add-location-button');
+      addButton.addEventListener('click', function(event) {
+        event.preventDefault();
+        var newInstrumentName = document.getElementById('add-location-input').value;
+        // Send AJAX request to the server
+        var xhr = new XMLHttpRequest();
+        xhr.open('POST', "{% url 'create-geographic-area-function' %}", true);
+        xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+        xhr.setRequestHeader('X-CSRFToken', '{{ csrf_token }}');
+        xhr.onreadystatechange = function() {
+          if (xhr.readyState === XMLHttpRequest.DONE) {
+            if (xhr.status === 200) {
+              console.log("New location created successfully!");
+              document.getElementById('add-location-input').value = '';
+            } else {
+              console.log("Error creating new location:", xhr.responseText);
+            }
+          }
+        };
+        xhr.send('locationName=' + encodeURIComponent(newInstrumentName));
+        xhr.send('newObjectForAutocomplete=' + encodeURIComponent('True'));
+      });
+    });
+
+    // Django maybe does not recognize disabled fields .. debug
+    function enableDisabledInputs() {
+        var inputs = document.querySelectorAll('input');
+        for (var i = 0; i < inputs.length; i++) {
+            if (inputs[i].disabled) {
+                inputs[i].disabled = false;
+            }
+        }
+    }
+
 </script>
 
-{{ form.media }}
+<style>
+    .flex-row{
+        display: flex; 
+        flex-direction: row;
+    }
+    [id$="tooltips"]{
+        padding-top: 2px;
+    }
+    .contribution-form-field{
+        margin-bottom: 1.5vh;
+        align-items: center;
+    }        
+    .btn{   
+        margin-bottom: 2%;
+        margin-top: 1%;
+    }
+    [id^="id_form-0-person_date"],
+    [id^="id_form-0-date"],
+    .input,#id_form-0-date_0,.btn{
+        margin-right: 1%;
+    }
+    .autocomplete-add-container{
+        align-items: stretch;
+        justify-content: space-between;
+    }
+    .add-more-input{
+        padding-bottom: 5px;
+        min-height: 32px;
+        display: block;
+        padding: .375rem .75rem;
+        height: fit-content;
+        margin-right: 5%;
+        margin-left: 5%;
+    }
+    .autocomplete-add{
+        display: flex;
+        flex-direction: row;
+        align-items: baseline;
+        justify-content: flex-end;
+        padding-bottom: 5px;
+        min-width: 55%;
+    }
+    .selection{
+        width: 60vh; /* overrides default which is in px */
+    }
+    [id^="id_select_section"]{
+        margin-right: 1%;
+        width: 25%
+    }
+    .info-tooltip-widget, [id^="id_form-0-person_range"][id$="_1"], [id^="id_form-0-certainty_of_attribution"] {
+        margin-left: 1%;
+    }
+    #add-type-input,#add-style-input,#add-instrument-input,
+    [id^="id_form"]:not([id^="id_form-0-certainty_of_attribution"],.info-tooltip-widget) {
+        padding: .375rem .75rem;
+        font-size: 1rem;
+        line-height: 1.5;
+        color: #495057;
+        background-color: #fff;
+        background-clip: padding-box;
+        border: 1px solid #ced4da;
+        border-radius: .25rem;
+        transition: border-color .15s ease-in-out,box-shadow .15s ease-in-out;
+    }
+    .select2-selection, span.select2-selection.select2-selection--single.form-control.autocomplete-select2 {
+        height: -webkit-fit-content;
+        min-height: 4vh;
+    } /* this works in chrome and firefox but in safari the min-height should be ~10vh... */
+    [id^="check-contributor"] {
+        align-self: first baseline;
+    }
+    .contribution-form label {
+        margin-bottom: 0;
+        margin-right: 1%;
+    }
+    div[id^="id_form-0-certainty_of_attribution"], label[for^="id_form-0-certainty_of_attribution"] {  
+        width: 50vh;
+    }
+    :disabled:not(button):not(.btn) {
+        background-color: #e9ecef !important;
+    }
+
+</style>
+
 {% endblock %}

--- a/database/templates/database/creation_form.html
+++ b/database/templates/database/creation_form.html
@@ -1,23 +1,19 @@
 {% extends "database/base.html" %}
 {% load static %}
-
 {% block content %}
-    <style>
-        label
-        {
-            color: black;
-            font-size: medium;
-        }
-        input[type=text] {
-            border: 1px solid #9b9b9b;
-            border-radius: 4px;
-            padding-left: 5px;
-            padding-top: 3px;
-            padding-bottom: 4px;
-            margin-top: 10px;
-            margin-bottom: 10px;
-        }
-    </style>
+
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
+    <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
+    <script type="text/javascript" src="{% static 'admin/js/vendor/jquery/jquery.js' %}"></script>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+
+</head>
+{{ form.media }}
+{% if error_message %}
+    <div class="alert alert-warning" role="alert">{{ error_message }}</div>
+{% endif %}
 <form method="post">
     {% csrf_token %}
     <h2> Create a Musical Work </h2>

--- a/database/urls.py
+++ b/database/urls.py
@@ -62,7 +62,7 @@ urlpatterns = [
         name="featuretype-detail",
     ),
     path(
-        "file-create/", FileCreationView.as_view(), name="file-creation", #testing
+        "file-create/", FileCreationView.as_view(), name="file-creation",
     ),
     path("files/", FileListView.as_view(), name="file-list"),
     path("files/<int:pk>", FileDetailView.as_view(), name="file-detail"),
@@ -135,15 +135,18 @@ urlpatterns = [
     path("ajax/add_to_cart/", add_to_cart, name="add-to-cart"),
     path("ajax/remove_from_cart/", remove_from_cart, name="remove-from-cart"),
     path("ajax/clear_cart/", clear_cart, name="clear-cart"),
-    # from create view
-    path("musical-work-create/", CreateMusicalWorkViewCustom.as_view(), name="musical-work-creation"), # testing
-
     # autocomplete views
     path("type-autocomplete/", TypeAutocomplete.as_view(), name="type-autocomplete"),
     path("file-autocomplete/", FileAutocomplete.as_view(), name="file-autocomplete"),
-    path('instrument-autcomplete/', InstrumentAutocomplete.as_view(), name='instrument-autocomplete'),
+    path('instrument-autocomplete/', InstrumentAutocomplete.as_view(), name='instrument-autocomplete'),
     path('geographicarea-autocomplete/', GeographicAreaAutocomplete.as_view(), name='geographicarea-autocomplete'),
     path('software-autocomplete/', SoftwareAutocomplete.as_view(), name='software-autocomplete'),
     path('archive-autocomplete/', ArchiveAutocomplete.as_view(), name='archive-autocomplete'),
     path('style-autocomplete/', StyleAutocomplete.as_view(), name='style-autocomplete'),
+    path('musicalwork-autocomplete/', MusicalWorkAutocomplete.as_view(), name='musicalwork-autocomplete'),
+    path('person-autocomplete/', PersonAutocomplete.as_view(), name='person-autocomplete'),
+    path('ajax/create-type-function/', create_type, name='create-type-function'),
+    path('ajax/create-style-function/', create_style, name='create-style-function'),
+    path('ajax/create-instrument-function/', create_instrument, name='create-instrument-function'),
+    path('ajax/create-geographic-area-function/', create_geographic_area, name='create-geographic-area-function'),
 ]

--- a/database/views/__init__.py
+++ b/database/views/__init__.py
@@ -38,7 +38,6 @@ from database.views.instrument import InstrumentDetailView, InstrumentListView
 from database.views.language import LanguageDetailView, LanguageListView
 from database.views.musical_work import MusicalWorkDetailView, MusicalWorkListView
 from database.views.create_view import CreateMusicalWorkViewCustom
-# from database.views.research_corpus_creation_view import CreateResearchCorpus
 from database.views.part import PartDetailView, PartListView
 from database.views.person import PersonDetailView, PersonListView
 from database.views.research_corpus import (
@@ -65,5 +64,6 @@ from database.views.cart import CartView, add_to_cart, remove_from_cart, clear_c
 from database.views.autocomplete_views import (
     StyleAutocomplete, TypeAutocomplete, GeographicAreaAutocomplete,
     InstrumentAutocomplete, SoftwareAutocomplete,
-    ArchiveAutocomplete, FileAutocomplete
+    ArchiveAutocomplete, FileAutocomplete, MusicalWorkAutocomplete, PersonAutocomplete
 )
+from database.views.autocomplete_create import create_type, create_style, create_geographic_area, create_instrument

--- a/database/views/autocomplete_create.py
+++ b/database/views/autocomplete_create.py
@@ -1,0 +1,58 @@
+from database.models import GenreAsInStyle, GenreAsInType, GeographicArea, Instrument, Software
+from django.shortcuts import render, redirect
+from django.http import JsonResponse
+
+def create_type(request):
+    if request.method == 'POST':
+        new_type_name = request.POST.get('typeName')
+        type_names = [type.name for type in GenreAsInType.objects.all()]
+        if new_type_name in type_names or len(new_type_name) < 2:
+            return JsonResponse({'error': 'Invalid type input'})
+        GenreAsInType.objects.create(name=new_type_name)
+        return JsonResponse({'message': 'New type created successfully'})
+    
+    return JsonResponse({'error': 'Invalid type method'})
+
+def create_style(request):
+    if request.method == 'POST':
+        new_style_name = request.POST.get('styleName')
+        style_names = [style.name for style in GenreAsInStyle.objects.all()]
+        if new_style_name in style_names or len(new_style_name) < 2:
+            return JsonResponse({'error': 'Invalid style input'})
+        GenreAsInStyle.objects.create(name=new_style_name)
+        return JsonResponse({'message': 'New style created successfully'})
+    
+    return JsonResponse({'error': 'Invalid style method'})
+
+def create_geographic_area(request):
+    if request.method == 'POST':
+        new_geographic_area_name = request.POST.get('geographicAreaName')
+        geographic_area_names = [geographic_area.name for geographic_area in GeographicArea.objects.all()]
+        if new_geographic_area_name in geographic_area_names or len(new_geographic_area_name) < 2:
+            return JsonResponse({'error': 'Invalid geographic area input'})
+        GeographicArea.objects.create(name=new_geographic_area_name)
+        return JsonResponse({'message': 'New geographic area created successfully'})
+    
+    return JsonResponse({'error': 'Invalid geographic area method'})
+
+def create_instrument(request):
+    if request.method == 'POST':
+        new_instrument_name = request.POST.get('instrumentName')
+        instrument_names = [instrument.name for instrument in Instrument.objects.all()]
+        if new_instrument_name in instrument_names or len(new_instrument_name) < 2:
+            return JsonResponse({'error': 'Invalid instrument input'})
+        Instrument.objects.create(name=new_instrument_name)
+        return JsonResponse({'message': 'New instrument created successfully'})
+    
+    return JsonResponse({'error': 'Invalid instrument method'})
+
+def create_software(request):
+    if request.method == 'POST':
+        new_software_name = request.POST.get('softwareName')
+        software_names = [software.name for software in Software.objects.all()]
+        if new_software_name in software_names or len(new_software_name) < 2:
+            return JsonResponse({'error': 'Invalid instrument input'})
+        Instrument.objects.create(name=new_software_name)
+        return JsonResponse({'message': 'New instrument created successfully'})
+    
+    return JsonResponse({'error': 'Invalid instrument method'})

--- a/database/views/autocomplete_views.py
+++ b/database/views/autocomplete_views.py
@@ -1,7 +1,7 @@
 from dal import autocomplete
-
+from django.db.models import Q
 from database.models import GenreAsInStyle, GenreAsInType, GeographicArea, \
-    Instrument, Software, Archive, File
+    Instrument, Software, Archive, File, MusicalWork, Person
 
 
 class StyleAutocomplete(autocomplete.Select2QuerySetView):
@@ -30,7 +30,7 @@ class FileAutocomplete(autocomplete.Select2QuerySetView):
 
 class TypeAutocomplete(autocomplete.Select2QuerySetView):
     def get_queryset(self):
-        qs = GenreAsInType.objects.all()
+        qs = GenreAsInType.objects.all().order_by("name")
 
         if self.q:
             qs = qs.filter(name__istartswith=self.q)
@@ -86,6 +86,53 @@ class ArchiveAutocomplete(autocomplete.Select2QuerySetView):
 
         if self.q:
             qs = qs.filter(name__istartswith=self.q)
+
+        return qs
+
+    def has_add_permission(self, request):
+        return True
+
+
+class MusicalWorkAutocomplete(autocomplete.Select2QuerySetView):
+    def get_queryset(self):
+        qs = MusicalWork.objects.all()
+
+        if self.q:
+            qs = qs.filter(Q(contributors__given_name__icontains=self.q) 
+                           | Q(contributors__surname__icontains=self.q)
+                           | Q(variant_titles__icontains=self.q))
+
+        return qs
+
+    def has_add_permission(self, request):
+        return True
+    
+    def get_results(self, context):
+        results = []
+
+        for musical_work in context["object_list"]:
+            result = {
+                "id": str(musical_work.pk),
+                "text": musical_work.variant_titles[0],  # First element of variant_titles
+                "selected_text": musical_work.variant_titles[0],  
+            }
+
+            if musical_work.contributors.exists():
+                first_contributor = musical_work.contributors.first()
+                result["text"] += " - " + str(first_contributor)  # Append first contributor
+                result["selected_text"] += " - " + str(first_contributor)  
+
+            results.append(result)
+
+        return results
+    
+class PersonAutocomplete(autocomplete.Select2QuerySetView):
+    def get_queryset(self):
+        qs = Person.objects.all()
+
+        if self.q:
+            qs = qs.filter(Q(given_name__icontains=self.q) 
+                           | Q(surname__icontains=self.q))
 
         return qs
 


### PR DESCRIPTION
Changes made for the autocomplete widgets; in the uploads form, the user is prompted to select a pre-existing object from the database; if it isn't there, they can create a new object with ajax.
Adds ajax functions so that objects can be created from the uploads form template. Required (1) a function in the template that triggers (2) a function in a separate view for creating objects and (3) updates to urls to reflect this change. 
Also adds more autocomplete functionality for person and work autocomplete.