### PR TITLE
Multi contributor form

### DIFF
--- a/database/forms/creation_forms.py
+++ b/database/forms/creation_forms.py
@@ -11,21 +11,50 @@ from database.models import (
     GeographicArea,
     Instrument,
     Part,
+    MusicalWork,
     Person,
     ResearchCorpus,
     Section,
     Software,
 )
+from django.db.models import CharField, Value, F
 from database.widgets.multiple_entry_widget import MultipleEntry
+from database.widgets.info_tooltip_widget import InfoTooltipWidget
 
 
 class ContributionForm(forms.Form):
-    person_given_name = forms.CharField(label="Person Given Name", required=True)
-    person_surname = forms.CharField(label="Person Surname", required=False)
-    person_range_date_birth = IntegerRangeField(label="Date of Birth", required=False)
-    person_range_date_death = IntegerRangeField(label="Date of Death", required=False)
 
-    role = forms.ChoiceField(
+    birth_info = forms.CharField(
+        label="",
+        required=False,
+        widget=InfoTooltipWidget(tooltip_text="Please enter the birth year of the contributor in either input box. If the specific year is not known, please enter a range."),
+    )
+
+    death_info = forms.CharField(
+        label="",
+        required=False,
+        widget=InfoTooltipWidget(tooltip_text="Please enter the birth year of the contributor in either input box. If the specific year is not known, please enter a range."),
+    )
+
+    person_from_db_0 = forms.ModelMultipleChoiceField(
+        label="Contributor's Name",
+        required=False,
+        queryset=Person.objects.all().order_by("surname"),
+        widget=autocomplete.ModelSelect2(
+            url="/person-autocomplete/", attrs={"class": "form-control autocomplete-select2",
+                                                "name": "person_from_db_0"}
+        ),
+    )
+
+    person_given_name_0 = forms.CharField(label="Contributor's Given Name*", required=False)
+    
+    person_surname_0 = forms.CharField(label="Contributor's Surname", required=False)
+    
+    person_range_date_birth_0 = IntegerRangeField(label="Date of Birth (range)*", required=False)
+    
+    person_range_date_death_0 = IntegerRangeField(label="Date of Death (range)*", required=False)
+    
+    role_0 = forms.ChoiceField(
         choices=(
             ("COMPOSER", "Composer"),
             ("ARRANGER", "Arranger"),
@@ -33,57 +62,203 @@ class ContributionForm(forms.Form):
             ("TRANSCRIBER", "Transcriber"),
             ("IMPROVISER", "Improviser"),
             ("PERFORMER", "Performer"),
-        )
+        ),
+        label="Role",
+        required=False
     )
 
-    certainty_of_attribution = forms.NullBooleanField(
+    certainty_of_attribution_0 = forms.NullBooleanField(
         required=False,
         widget=forms.RadioSelect(
             choices=((True, "Certain"), (False, "Uncertain"), (None, "Unknown"))
         ),
+        label="Certainty of attribution"
     )
-    location = forms.ModelChoiceField(
+
+    location_0 = forms.ModelChoiceField(
         required=False,
-        queryset=GeographicArea.objects.all(),
+        queryset=GeographicArea.objects.all().order_by("name"),
         widget=autocomplete.ModelSelect2(
-            url="geographicarea-autocomplete", attrs={"class": "form-control"}
+            url="/geographicarea-autocomplete/", attrs={"class": "form-control autocomplete-select2",
+                                                        "name": "location_0"}
+        ),
+        label="Location"
+    )
+
+    date_0 = IntegerRangeField(label="Date of Contribution (range)", required=False)
+    
+    person_from_db_1 = forms.ModelMultipleChoiceField(
+        label="Contributor's Name",
+        required=False,
+        queryset=Person.objects.all().order_by("surname"),
+        widget=autocomplete.ModelSelect2(
+            url="/person-autocomplete/", attrs={"class": "form-control autocomplete-select2",
+                                                "name": "person_from_db_1"}
         ),
     )
-    date = IntegerRangeField(label="Date of Contribution", required=False)
 
+    person_given_name_1 = forms.CharField(label="Contributor's Given Name*", required=False)
+    
+    person_surname_1 = forms.CharField(label="Contributor's Surname", required=False)
+    
+    person_range_date_birth_1 = IntegerRangeField(label="Date of Birth (range)*", required=False)
+    
+    person_range_date_death_1 = IntegerRangeField(label="Date of Death (range)*", required=False)
+    
+    role_1 = forms.ChoiceField(
+        choices=(
+            ("COMPOSER", "Composer"),
+            ("ARRANGER", "Arranger"),
+            ("AUTHOR", "Author of Text"),
+            ("TRANSCRIBER", "Transcriber"),
+            ("IMPROVISER", "Improviser"),
+            ("PERFORMER", "Performer"),
+        ),
+        label="Role",
+        required=False
+    )
 
+    certainty_of_attribution_1 = forms.NullBooleanField(
+        required=False,
+        widget=forms.RadioSelect(
+            choices=((True, "Certain"), (False, "Uncertain"), (None, "Unknown"))
+        ),
+        label="Certainty of attribution"
+    )
+
+    location_1 = forms.ModelChoiceField(
+        required=False,
+        queryset=GeographicArea.objects.all().order_by("name"),
+        widget=autocomplete.ModelSelect2(
+            url="/geographicarea-autocomplete/", attrs={"class": "form-control autocomplete-select2",
+                                                        "name": "location_1"}
+        ),
+        label="Location"
+    )
+
+    date_1 = IntegerRangeField(label="Date of Contribution (range)", required=False)
+    
+    person_from_db_2 = forms.ModelMultipleChoiceField(
+        label="Contributor's Name",
+        required=False,
+        queryset=Person.objects.all().order_by("surname"),
+        widget=autocomplete.ModelSelect2(
+            url="/person-autocomplete/", attrs={"class": "form-control autocomplete-select2",
+                                                "name": "person_from_db_2"}
+        ),
+    )
+
+    person_given_name_2 = forms.CharField(label="Contributor's Given Name*", required=False)
+    
+    person_surname_2 = forms.CharField(label="Contributor's Surname", required=False)
+    
+    person_range_date_birth_2 = IntegerRangeField(label="Date of Birth (range)*", required=False)
+    
+    person_range_date_death_2 = IntegerRangeField(label="Date of Death (range)*", required=False)
+    
+    role_2 = forms.ChoiceField(
+        choices=(
+            ("COMPOSER", "Composer"),
+            ("ARRANGER", "Arranger"),
+            ("AUTHOR", "Author of Text"),
+            ("TRANSCRIBER", "Transcriber"),
+            ("IMPROVISER", "Improviser"),
+            ("PERFORMER", "Performer"),
+        ),
+        label="Role",
+        required=False
+    )
+
+    certainty_of_attribution_2 = forms.NullBooleanField(
+        required=False,
+        widget=forms.RadioSelect(
+            choices=((True, "Certain"), (False, "Uncertain"), (None, "Unknown"))
+        ),
+        label="Certainty of attribution"
+    )
+
+    location_2 = forms.ModelChoiceField(
+        required=False,
+        queryset=GeographicArea.objects.all().order_by("name"),
+        widget=autocomplete.ModelSelect2(
+            url="/geographicarea-autocomplete/", attrs={"class": "form-control autocomplete-select2",
+                                                        "name": "location_2"}
+        ),
+        label="Location"
+    )
+
+    date_2 = IntegerRangeField(label="Date of Contribution (range)", required=False)
+    
+  
 class WorkInfoForm(forms.Form):
+    
+    contribution_tooltips = forms.CharField(
+        label="",
+        required=False,
+        widget=InfoTooltipWidget(tooltip_text="This field is not required if the musical work already exists in the database. If you are creating a new musical work, please input the contributor's name, year of birth, and year of death."),
+    )
     attrs = {
         "name": "variant_title",
         "class": "form-control",
         "placeholder": "e.g. Eroica",
     }
-    widget = MultipleEntry(attrs=attrs)
-
+    
     variant_titles = forms.CharField(
-        label="Variant Titles", widget=widget, required=False
+        label="Variant Titles", widget=MultipleEntry(attrs=attrs), required=False
+    )
+    
+    variant_titles_from_db = forms.CharField(
+        label="Variant Titles", widget=MultipleEntry(attrs = {
+            "name": "variant_title_from_db",
+            "class": "form-control",
+            "placeholder": "e.g. Eroica",
+        }), required=False
+    )
+
+    variant_titles_from_db_tooltips = forms.CharField(
+        label="",
+        required=False,
+        widget=InfoTooltipWidget(tooltip_text="Input new titles to be added to the musical work."),
     )
 
     title = forms.CharField(
-        label="Title *",
+        label="Title*",
         widget=forms.TextInput(
             attrs={"class": "form-control", "placeholder": "e.g. Symphony No.3 Op. 55"}
         ),
+        required=False
     )
 
+    title_from_db = forms.ModelMultipleChoiceField(
+        label="Title*",
+        required=False,
+        queryset=MusicalWork.objects.annotate(
+            first_variant_title=F('variant_titles__0')
+        ).order_by('first_variant_title'),
+        widget=autocomplete.ModelSelect2(
+            url="/musicalwork-autocomplete/", attrs={"class": "form-control autocomplete-select2", "name": "title_from_db"}
+        ),
+    )
+
+    title_from_db_tooltips = forms.CharField(
+        label="",
+        required=False,
+        widget=InfoTooltipWidget(tooltip_text="Can't find what you're looking for? Click the checkbox below."),
+    )
+    
     genre_as_in_style = forms.ModelMultipleChoiceField(
         required=False,
         queryset=GenreAsInStyle.objects.all(),
-        widget=autocomplete.ModelSelect2Multiple(
-            url="style-autocomplete", attrs={"class": "form-control"}
+        widget=autocomplete.ModelSelect2(#Multiple(
+            url="/style-autocomplete/", attrs={"class": "form-control"}
         ),
     )
 
     genre_as_in_type = forms.ModelMultipleChoiceField(
         required=False,
-        queryset=GenreAsInType.objects.all(),
-        widget=autocomplete.ModelSelect2Multiple(
-            url="type-autocomplete", attrs={"class": "form-control"}
+        queryset=GenreAsInType.objects.all().order_by("name"),
+        widget=autocomplete.ModelSelect2(#Multiple(
+            url="/type-autocomplete/", attrs={"class": "form-control autocomplete-select2"}
         ),
     )
 
@@ -101,27 +276,81 @@ class WorkInfoForm(forms.Form):
 
     instruments = forms.ModelMultipleChoiceField(
         required=False,
-        queryset=Instrument.objects.all(),
+        queryset=Instrument.objects.all().order_by("name"),
         widget=autocomplete.ModelSelect2Multiple(
-            url="instrument-autocomplete", attrs={"class": "form-control"}
+            url="/instrument-autocomplete/", attrs={"class": "form-control autocomplete-select2"}
         ),
     )
 
-    attrs = {
-        "name": "section_title",
-        "class": "form-control",
-        "placeholder": "e.g. I. Allegro con brio",
-    }
-    widget = MultipleEntry(attrs=attrs)
-    sections = forms.CharField(label="Sections", widget=widget, required=False)
+    sections = forms.CharField(
+        label="Sections",
+        required=False,
+        widget=forms.TextInput(
+            attrs={
+                "class": "form-control",
+                "placeholder": "e.g. I. Allegro con brio",
+            }
+        ),
+    )
+    select_section = forms.ChoiceField(
+        choices=[
+            ('1', '1. Kyrie'),
+            ('2', '2. Gloria'),
+            ('3', '3. Credo'),
+            ('4', '4. Sanctus'),
+            ('5', '5. Agnus'),
+        ],
+        widget=forms.Select(attrs={"class": "form-control"}),
+        required=False
+    )
 
+    sections_from_db = forms.CharField(
+        label="Sections",
+        required=False,
+        widget=forms.TextInput(
+            attrs={
+                "class": "form-control",
+                "placeholder": "e.g. I. Allegro con brio",
+            }
+        ),
+    )
+    select_section_from_db = forms.ChoiceField(
+        choices=[
+            ('1', '1. Kyrie'),
+            ('2', '2. Gloria'),
+            ('3', '3. Credo'),
+            ('4', '4. Sanctus'),
+            ('5', '5. Agnus'),
+        ],
+        widget=forms.Select(attrs={"class": "form-control"}),
+    )
+
+    sections_from_db_tooltips = forms.CharField(
+        label="",
+        required=False,
+        widget=InfoTooltipWidget(tooltip_text="Input sections to be added to the musical work. Please only input new sections. If the section you are looking for already exists, please skip this section."),
+    )
+    
 
 class FileForm(forms.Form):
-    file = forms.FileField(max_length=255)
+    file = forms.FileField(max_length=255, widget=forms.ClearableFileInput(attrs={'class': 'form-control'}),
+                           required=False)
     software = forms.ModelChoiceField(
         queryset=Software.objects.all(),
         required=False,
         widget=autocomplete.ModelSelect2(
-            url="software-autocomplete", attrs={"class": "form-control-file"}
+            url="/software-autocomplete/", attrs={"class": "form-control-file form-control"}
         ),
     )
+    TYPES = (
+        ("sym", "Symbolic Music"),
+        ("txt", "Text"),
+        ("img", "Image"),
+        ("audio", "Audio"),
+    )
+    file_type = forms.ChoiceField(
+        label="Source Type",
+        choices=TYPES,
+        widget=forms.Select(attrs={"class": "form-control"}),
+    )
+  

--- a/database/templates/database/creation_form.html
+++ b/database/templates/database/creation_form.html
@@ -17,75 +17,387 @@
 <form method="post">
     {% csrf_token %}
     <h2> Create a Musical Work </h2>
-
+    <br>
     <h3> Title </h3>
     <div id='work_form'>
     <p>
-        What is the title of the work? 
+        What is the title of the work? If it is already in the database, select it. Otherwise, enter it below.
         Click the green button to add variant titles or nicknames.
         Please include opus number or catalogue numbers if applicable (e.g., 
-        Op. 55, D960, BWV 202)
+        Op. 55, D960, BWV 202).
     </p>
+    <div class="work-container">
+        <div id="work-in-database">
+            <div class="flex-row">
+                {{ form.title_from_db.label_tag }}
+                {{ form.title_from_db_tooltips }}
+            </div>
+            {{ form.title_from_db }}
+            <br><br>
+            <div class="multiple-entry"> 
+                <div class="flex-row">
+                    {{ form.variant_titles_from_db.label_tag }}
+                    {{ form.variant_titles_from_db_tooltips }}
+                </div>
+                {{ form.variant_titles_from_db }}
+            </div>
+            <div class="multiple-entry"> 
+                <div class="flex-row"> 
+                    {{ form.sections_from_db.label_tag }}
+                    {{ form.sections_from_db_tooltips }}
+                </div>
+                <div class="select-div-parent" style="display: flex; flex-direction: column;">
+                    <div class="select-div flex-row">
+                        {{ form.select_section_from_db }}
+                        {{ form.sections_from_db }}
+                    </div>
+                </div>
+                <div class="flex-row">
+                    <input class="btn btn-success btn-sm" type="button" value="+" onclick="addSectionField(0)">
+                    <input class="btn btn-danger btn-sm" type="button" value="-" onclick="deleteSectionField()">
+                </div>
+            </div>
+            <br>
+            <div class="form-check form-switch">
+                <input class="form-check-input" type="checkbox" value="" id="flexSwitchCheckDefault" name="work_not_in_database">
+                <label class="form-check-label" for="flexSwitchCheckDefault">
+                <p>Musical Work<b> not </b>in database</p>
+                </label>
+            </div>
+        </div>
         {{ form.title.label_tag }}
         {{ form.title }}
-        {{ form.variant_titles.label_tag }}
-        {{ form.variant_titles }}
         <br>
-        {{ form.sections.label_tag }}
-        {{ form.sections }}
+        <div class="multiple-entry">
+            {{ form.variant_titles.label_tag }}
+            <div id="variant-title-div">{{ form.variant_titles }}</div>
+        </div>
+        <div class="multiple-entry"> 
+            {{ form.sections.label_tag }}
+            <div class="select-div-parent" style="display: flex; flex-direction: column;">
+                <div class="select-div flex-row">
+                    {{ form.select_section }}
+                    {{ form.sections }}
+                </div>
+            </div>
+            <div class="flex-row">
+                <input class="btn btn-success btn-sm" type="button" value="+" onclick="addSectionField(1)">
+                <input class="btn btn-danger btn-sm" type="button" value="-" onclick="deleteSectionField()">
+            </div>
+        </div>
+    </div>
     <br>
-    <h3> Contributions </h3>
+    <div class="flex-row">
+        <h3> Contributions </h3> {{ form.contribution_tooltips }} 
+    </div>
     {{ contribution_form.management_form }}
         <div id="form_set">
-            <p>
+            <p><i>Please complete one contributor before adding another.</i>
                 Who created the work? 
                 Use the drop-down menu to choose between different kinds of 
                 contributions. Add more contributors with the green 
                 button. 
             </p>
-            {% for form in contribution_form %}
-                {{ form.as_p }}
+            <div id="contribution-forms">
+            {% for contribution_form in contribution_form %}
+                <div class="contribution-form" id="contribution-form_0">
+                    <div class="contribution-form-field flex-row">
+                        {{ contribution_form.person_from_db_0.label_tag }}
+                        {{ contribution_form.person_from_db_0 }}
+                    </div>
+                    <div class="contribution-form-field flex-row form-check">
+                        <input class="form-check-input check-contributor" id="check-contributor_0" type="checkbox" value="" name="person_not_in_database_0">
+                        <label class="form-check-label" for="check-contributor_0">Person is not in database</label>
+                    </div>
+                    <div class="contribution-form-field flex-row">
+                        {{ contribution_form.person_given_name_0.label_tag }}
+                        {{ contribution_form.person_given_name_0 }}
+                    </div>
+                    <div class="contribution-form-field flex-row">
+                        {{ contribution_form.person_surname_0.label_tag }}
+                        {{ contribution_form.person_surname_0 }}
+                    </div>
+                    <div class="contribution-form-field flex-row">
+                        {{ contribution_form.person_range_date_birth_0.label_tag }}
+                        {{ contribution_form.person_range_date_birth_0 }}
+                        {{ contribution_form.birth_info }}
+                    </div>
+                    <div class="contribution-form-field flex-row">
+                        {{ contribution_form.person_range_date_death_0.label_tag }}
+                        {{ contribution_form.person_range_date_death_0 }}
+                        {{ contribution_form.death_info }}
+                    </div>
+                    <div class="contribution-form-field flex-row">
+                        {{ contribution_form.role_0.label_tag }}
+                        {{ contribution_form.role_0 }}
+                    </div>
+                    <div class="contribution-form-field flex-row">
+                        {{ contribution_form.certainty_of_attribution_0.label_tag }}
+                    </div>
+                    <div class="contribution-form-field flex-row">
+                        {{ contribution_form.certainty_of_attribution_0 }}
+                    </div>
+                    <div class="contribution-form-field flex-row">
+                        {{ contribution_form.location_0.label_tag }}
+                        {{ contribution_form.location_0 }}
+                    </div>
+                    <div class="contribution-form-field flex-row">
+                        <div class="form-check" style="min-width: 23vh;">
+                            <input class="form-check-input location-check" type="checkbox" value="" id="check-location_0" name="location_not_in_database">
+                            <label class="form-check-label" for="check-location_0">
+                            <p>Location not in database</p>
+                            </label>
+                        </div>
+                        <div class="autocomplete-add" style="justify-content: center;">
+                            <input type="text" placeholder="e.g. Court of Marie V" class="add-more-input form-control" id="add-location-input_0"/>
+                            <button class="btn btn-success btn-sm add-more-button" id="add-location-button_0">Add Location</button>
+                        </div>
+                    </div>
+                    <div class="contribution-form-field flex-row">
+                        {{ contribution_form.date_0.label_tag }}
+                        {{ contribution_form.date_0 }}
+                    </div>
+                </div>
             {% endfor %}
+            </div>
         </div>
-    <input input class="btn btn-success btn-sm" type="button" id="add_more" value="+">
+    <input class="btn btn-success" type="button" id="add_more" value="+">
+    
+    <br><br>
     <h3> Genre(s) </h3>
         <p>
             What type of piece is this? (e.g., song, symphony, motet)
         </p>
-        {{ form.genre_as_in_type }}
+        <div class="autocomplete-add-container flex-row">
+            {{ form.genre_as_in_type }}
+            <div class="autocomplete-add">
+                <input type="text" class="add-more-input" id="add-type-input"/>
+                <button class="btn btn-success btn-sm add-more-button" id="add-type-button">Add New Type</button>
+            </div>
+        </div>
+        <div class="line">
+            <div class="form-check">
+                <input class="form-check-input" type="checkbox" value="" id="flexCheckType" name="type_not_in_database">
+                <label class="form-check-label" for="flexCheckType">
+                <p>Type not in database</p>
+                </label>
+            </div>
+        </div>
+            
         <p>
             What style is this piece? (e.g., classical, jazz)
         </p>
-        {{ form.genre_as_in_style }}
-
+        <div class="autocomplete-add-container flex-row">
+            {{ form.genre_as_in_style }}
+            <div class="autocomplete-add">
+                <input type="text" class="add-more-input" id="add-style-input"/>
+                <button class="btn btn-success btn-sm add-more-button" id="add-style-button">Add New Style</button>
+            </div>
+        </div>
+        <div class="flex-row">
+            <div class="form-check">
+                <input class="form-check-input" type="checkbox" value="" id="flexCheckStyle" name="style_not_in_database">
+                <label class="form-check-label" for="flexCheckStyle">
+                <p>Style not in database</p>
+                </label>
+            </div>
+        </div>
         {{ form.sacred_or_secular.label_tag }}
         {{ form.sacred_or_secular }}
     </div>
 
     <div>
+    <br>
     <h3> Medium of Performance </h3>
         <p>
             Please enter the instruments or voices below.
         </p>
         {{ form.instruments.label_tag }}
-        {{ form.instruments }}
+        <div class="autocomplete-add-container flex-row">
+            {{ form.instruments }}
+            <div class="autocomplete-add">
+                <input type="text" class="add-more-input" id="add-instrument-input"/>
+                <button class="btn btn-success btn-sm add-more-button" id="add-instrument-button">Add New Instrument</button>
+            </div>
+        </div>
+        <div class="line">
+            <div class="form-check">
+                <input class="form-check-input" type="checkbox" value="" id="flexCheckInstrument" name="instrument_not_in_database">
+                <label class="form-check-label" for="flexCheckInstrument">
+                <p>Instrument not in database</p>
+                </label>
+            </div>
+        </div>
     </div>
-    <button type="submit" value="Submit" class="btn btn-primary">Submit</button>
+    <br><br>
+    <button type="submit" value="Submit" class="btn-block btn btn-lg btn-primary">Submit</button>
+    <br>
 </form>
 
-
-<div id="empty_form" style="display:none">
-        <div id=extra_form>
-            {{ contribution_form.empty_form.as_p }}
-        <div>
-</div>
-
 <script>
+    var form_idx = 0;
+    var numContributors = 1;
+    var maxNumContributors = 3;
+
     $('#add_more').click(function() {
-        var form_idx = $('#id_form-TOTAL_FORMS').val();
-        $('#form_set').append($('#empty_form').html().replace(/__prefix__/g, form_idx));
-        $('#id_form-TOTAL_FORMS').val(parseInt(form_idx) + 1);
+        if (numContributors >= maxNumContributors) {
+            return;
+        }
+        original_form_idx = 0;
+        form_idx++;
+        var parentDiv = $('<div class="contribution-form" id="contribution-form-' + form_idx + '"></div>');
+        // Duplicate form with unique ids for all widgets
+        var regex = new RegExp('_' + original_form_idx + '\\b', 'g');
+        var regexRange0 = new RegExp('_' + original_form_idx + '_0' + '\\b', 'g');
+        var regexRange1 = new RegExp('_' + original_form_idx + '_1' + '\\b', 'g');
+        var new_form = $($('.contribution-form').html().replace(regex, '_' + form_idx)
+            .replace(regexRange0, '_' + form_idx + '_0').replace(regexRange1, '_' + form_idx + '_1'));
+        new_form.find('span[data-select2-id]').attr('data-select2-id', form_idx);
+        
+        // Initialize new form inputs to disabled
+        new_form.find(':input').slice(2,8).prop('disabled', true);
+        var locationInput = $('#add-location-input_' + form_idx);
+        locationInput.prop('disabled', true);
+        
+        // Listeners for enable/disable checkboxes
+        new_form.find('.check-contributor').on('change', function() {
+            var cur_form = $(this).closest('.contribution-form');
+            var isChecked = $(this).prop('checked');
+            cur_form.find(':input').slice(3,9).prop('disabled', !isChecked);
+        });
+        new_form.find('#check-location_'+form_idx).on('change', function() {
+            var isChecked = $(this).prop('checked');
+            $('#add-location-input_' + form_idx).prop('disabled', !isChecked);
+            $('#add-location-button_' + form_idx).prop('disabled', !isChecked);
+        });
+        
+        // Add delete button to contribution form
+        const deleteButton = document.createElement('input');
+        deleteButton.className = 'btn btn-danger';
+        deleteButton.type = 'button';
+        deleteButton.id = 'delete_form';
+        deleteButton.value = '-';
+        deleteButton.setAttribute('aria-label', 'Delete the below form.');
+        deleteButton.addEventListener('click', function() {
+            form_idx = $('#id_form-TOTAL_FORMS').val();
+            parentDiv.remove();
+            form_idx = parseInt(form_idx) - 1;
+            numContributors--;
+            $('#id_form-TOTAL_FORMS').val(form_idx);
+        });
+        
+        // Append all new elements to the DOM
+        var h5Element = $('<h5 style="align-self: center;padding-bottom: 1%;">Contributor ' + ++numContributors + '</h5>');
+        var contributorTitleDiv = $('<div class="line"></div>');
+        contributorTitleDiv.append(deleteButton);
+        contributorTitleDiv.append(h5Element);
+        parentDiv.append(contributorTitleDiv);
+        parentDiv.append(new_form);
+        $('#contribution-forms').append(parentDiv);
+        // DAL gets duplicated weirdly, remove extra dropdown
+        $('#form_set').find('span.select2-container.select2-container--default').last().html('').remove();
+        $('#form_set').find('span.select2-container.select2-container--default').last().html('').remove();
+        $('#id_form-TOTAL_FORMS').val(form_idx);
     });
+    
+    var sectionDivCount = 1; 
+
+    function addSectionField(num) {
+        var div = document.getElementsByClassName("select-div");
+        div = div[num];
+        var div_parent = document.getElementsByClassName("select-div-parent");
+        div_parent = div_parent[num];
+        var div_clone = div.cloneNode(false);
+        var sections = document.getElementById("id_sections");
+        var select_section = document.getElementById("id_select_section");
+        var select_section_clone = select_section.cloneNode(true);
+        select_section_clone.id = "id_select_section" + sectionDivCount;
+        select_section_clone.value = "";
+        div_clone.appendChild(select_section_clone);
+        var sections_clone = sections.cloneNode(true);
+        sections_clone.id = "id_sections" + sectionDivCount;
+        sections_clone.value = "";
+        div_clone.appendChild(sections_clone);
+        div_parent.appendChild(div_clone);
+        sectionDivCount++;
+    }
+
+    function deleteSectionField() {
+        if (sectionDivCount === 1){
+            return
+        }
+        document.getElementById("id_sections" + (sectionDivCount - 1)).remove();
+        document.getElementById("id_select_section" + (sectionDivCount - 1)).remove();
+        sectionDivCount--;
+    }
+
+    // Disable form if checkbox indicating musical work already exists in the database is selected
+    $(document).ready(function() {
+        // Initialize all contributor form elements relating to person to disabled 
+        var form = document.getElementById('contribution-form_0');
+        var inputs = form.getElementsByTagName('input');
+        for (var i = 1; i < 7; i++) {
+            inputs[i].disabled = true;
+        }
+
+        var formElements = $('.work-container :input:not(#work-in-database :input)');
+        var formLabels = $('.work-container label:not(#work-in-database label)');
+        formLabels.hide();
+        formElements.prop('disabled', true);
+        formElements.hide();
+        
+        var addNewInputs = $('.autocomplete-add :input');
+        addNewInputs.prop('disabled', true);
+
+        var workCheckbox = $('#flexSwitchCheckDefault');
+        workCheckbox.on('click', function() {
+            var formElements = $('.work-container :input:not(#work-in-database :input)');
+            var formLabels = $('.work-container label:not(#work-in-database label)');
+            var checkboxChecked = $('#flexSwitchCheckDefault').is(':checked');
+
+            if (checkboxChecked) {
+                formElements.prop('disabled', false);
+                formElements.show();
+                formLabels.show();
+            } else {
+                formElements.prop('disabled', true);
+                formElements.hide();
+                formLabels.hide();
+            }
+        });
+
+        var instrumentCheckbox = $('#flexCheckInstrument');
+        instrumentCheckbox.on('click', function() {
+            $('#add-instrument-input').prop('disabled', !instrumentCheckbox.is(':checked'));
+            $('#add-instrument-button').prop('disabled', !instrumentCheckbox.is(':checked'));
+        });
+
+        var styleCheckbox = $('#flexCheckStyle');
+        styleCheckbox.on('click', function() {
+            var styleInput = $('#add-style-input').prop('disabled', !styleCheckbox.is(':checked'));
+            var styleButton = $('#add-style-button').prop('disabled', !styleCheckbox.is(':checked'));
+        });
+
+        var typeCheckbox = $('#flexCheckType');
+        typeCheckbox.on('click', function() {
+            var typeInput = $('#add-type-input').prop('disabled', !typeCheckbox.is(':checked'));
+            var typeButton = $('#add-type-button').prop('disabled', !typeCheckbox.is(':checked'));
+        });
+
+        var locationCheckbox = $('#check-location_0'); 
+        locationCheckbox.on('click', function() {
+            $('#add-location-input_0').prop('disabled', !locationCheckbox.is(':checked'));
+            $('#add-location-button_0').prop('disabled', !locationCheckbox.is(':checked'));
+        });
+
+        $('#form_set').find('#check-contributor_' + form_idx).on('change', function() {
+            var cur_form = $(this).closest('.contribution-form');
+            var isChecked = $(this).prop('checked');
+            cur_form.find(':input').slice(2,8).prop('disabled', !isChecked);
+        });
+
+    });
+
     document.addEventListener('DOMContentLoaded', function() {
       // Listen for add Genre Type
       var addButton = document.getElementById('add-type-button');
@@ -189,16 +501,6 @@
         xhr.send('newObjectForAutocomplete=' + encodeURIComponent('True'));
       });
     });
-
-    // Django maybe does not recognize disabled fields .. debug
-    function enableDisabledInputs() {
-        var inputs = document.querySelectorAll('input');
-        for (var i = 0; i < inputs.length; i++) {
-            if (inputs[i].disabled) {
-                inputs[i].disabled = false;
-            }
-        }
-    }
 
 </script>
 

--- a/database/views/creation_view.py
+++ b/database/views/creation_view.py
@@ -1,12 +1,13 @@
 import datetime
 from urllib import request
 from django.contrib.auth.decorators import login_required, permission_required
-from construct import ValidationError
+from django.core.exceptions import ValidationError
 from django.forms import formset_factory
 from django.http import HttpResponseRedirect
 from django.shortcuts import render, redirect
 from django.views import View
 from django.views.generic import FormView
+from django.db.models import Q
 
 from database.forms.creation_forms import (ContributionForm, FileForm,
                                            WorkInfoForm)
@@ -26,11 +27,12 @@ class CreationView(FormView):
         """
         if not request.user.has_perm('simssadb.creation_access'):
             return redirect('/')
-    
+        
         form = WorkInfoForm()
         contribution_forms = formset_factory(ContributionForm)
         return self.render_to_response(
-                self.get_context_data(form=form,
+                self.get_context_data(error_message=None,
+                                      form=form,
                                       contribution_form=contribution_forms))
 
     def post(self, request, *args, **kwargs):
@@ -39,135 +41,197 @@ class CreationView(FormView):
         formsets with the passed POST variables and then checking them for
         validity.
         """
-        form = WorkInfoForm(request.POST)
-        contribution_formset = formset_factory(ContributionForm)
-        # I'm getting the variant titles and sections before validation
-        # because when the is_valid() method is called, the lists of
-        # variant_titles and sections are transformed onto single values
 
+        # The form expects a list of titles and people for each autocomplete widget, 
+        # so it must be changed before validation. Must be done in the original POST data, 
+        # not in the cleaned data (i.e. not by overriding clean) nor in form_valid - an error will be thrown.
+        post_data = request.POST.copy() # to make it mutable
+        title = request.POST.get('title_from_db')
+        if not title == None:
+            post_data['title_from_db'] = [title]
+        else:
+            post_data['title_from_db'] = None
+        person_count = 0
+        for key in range(0,3):
+            if request.POST.get(f'form-0-person_from_db_{key}') == None:
+                continue
+            person_count = person_count + 1 
+            post_data[f'form-0-person_from_db_{key}'] = request.POST.getlist(f'form-0-person_from_db_{key}')
+        genre_as_in_type = request.POST.getlist('genre_as_in_type')
+        if genre_as_in_type:
+            post_data['genre_as_in_type'] = genre_as_in_type
+        genre_as_in_style = request.POST.getlist('genre_as_in_style')
+        if genre_as_in_style:
+            post_data['genre_as_in_style'] = genre_as_in_style
+        request.POST = post_data
+        
+        # List items such as variant titles and sections are gotten before validation and reassigned after,
+        # because when the is_valid() method is called, lists from the form are transformed into single values.
         # TODO: check titles and sections for SQL injections etc
         variant_titles = request.POST.getlist('variant_title')
-        sections = request.POST.getlist('section_title')
+        sections = request.POST.getlist('sections')
+        select_section = request.POST.getlist('select_section')
+        variant_titles_from_db = request.POST.getlist('variant_titles_from_db')
+        sections_from_db = request.POST.getlist('sections_from_db')
+        select_section_from_db = request.POST.getlist('select_section_from_db')
+
+        form = WorkInfoForm(request.POST)
+        contribution_formset = formset_factory(ContributionForm)
         contribution_forms = contribution_formset(request.POST)
-        if (form.is_valid() and contribution_forms.is_valid()):
+        if form.is_valid() and contribution_forms.is_valid():
+            # Check that form is logically valid
+            if (not form.cleaned_data['title_from_db'] and not form.cleaned_data['title']):
+                return self.form_invalid(form, contribution_forms)
+
             form.cleaned_data['variant_titles'] = variant_titles
             form.cleaned_data['sections'] = sections
+            form.cleaned_data['select_section'] = select_section
+            form.cleaned_data['variant_titles_from_db'] = variant_titles_from_db
+            form.cleaned_data['sections_from_db'] = sections_from_db
+            form.cleaned_data['select_section_from_db'] = select_section_from_db
+            # Checkboxes are html elements and not django widgets, must add them to the cleaned data manually
+            form.cleaned_data['work_in_database'] = request.POST.get('work_not_in_database') == None
+            for i in range(0,person_count): 
+                form.cleaned_data[f'person_in_database_{i}'] = request.POST.get(f'person_not_in_database_{i}') == None
             return self.form_valid(form, contribution_forms, request)
         else:
+            print(form.errors)
+            print(contribution_forms.errors)
             return self.form_invalid(form, contribution_forms)
-
+    
     def form_valid(self, form, contribution_forms, request):
         """
         Called if all forms are valid.
         """
-        # Get all the data from the form
-        title = form.cleaned_data['title']
-        variant_titles = form.cleaned_data['variant_titles']
         styles = form.cleaned_data['genre_as_in_style']
         types = form.cleaned_data['genre_as_in_type']
         instruments = form.cleaned_data['instruments']
         sacred_or_secular = form.cleaned_data['sacred_or_secular']
         if not sacred_or_secular:
             sacred_or_secular = None
-        sections = form.cleaned_data['sections']
-
-        # Create a musical work
-        titles = [title] + variant_titles
-        work = MusicalWork(variant_titles=titles,
-                           sacred_or_secular=sacred_or_secular)
-        work.save()
-        work.genres_as_in_style.set(styles)
-        work.genres_as_in_type.set(types)
-        work.save()
+        if form.cleaned_data['work_in_database'] == True:
+            work = form.cleaned_data['title_from_db'].first()
+            variant_titles = form.cleaned_data['variant_titles_from_db']
+            sections = form.cleaned_data['sections_from_db']
+            section_titles = form.cleaned_data['select_section_from_db']
+            if len(variant_titles) != 0:
+                # Remove repeats regardless of case
+                for variant_title in variant_titles:
+                    lower_variant_title = variant_title.lower()
+                    if lower_variant_title in [title.lower() for title in work.variant_titles]:
+                        variant_titles.remove(variant_title)
+                work.variant_titles = variant_titles + work.variant_titles
+            work.save()
+        else:
+            title = form.cleaned_data['title']
+            variant_titles = form.cleaned_data['variant_titles']
+            sections = form.cleaned_data['sections']
+            section_titles = form.cleaned_data['select_section']
+            titles = [title] 
+            if len(variant_titles) != 0:
+                for variant_title in variant_titles:  
+                    titles.append(variant_title) if not len(variant_title) == 0 else None
+            work = MusicalWork(variant_titles=titles,
+                            sacred_or_secular=sacred_or_secular)
+            work.save()
+            work.genres_as_in_style.set(styles)
+            work.genres_as_in_type.set(types)
+            work.save()            
 
         # Create sections
-        for count, entry in enumerate(sections, start=1):
-            if entry == "":
-                entry = title + " Section " + str(count)
+        for i in range(len(sections)):
+            if sections[i] == '':
+                continue
+            count = section_titles[i]
+            entry = sections[i]
             section = Section(title=entry, musical_work=work)
             section.save()
-            # Create parts for each section
+            section.ordering = int(count)
+            section.save()
+            work.sections.add(section)
+            # Create parts for each new section
             for instrument in instruments:
-                part = Part(written_for=instrument, section=section)
-                part.save()
+                part = Part.objects.get_or_create(written_for=instrument, section=section)
+                part_object = Part.objects.get(written_for=instrument, section=section)
+                section.parts.add(part_object)
+
+        # TODO Can add feature to pick if part for full work or for certain section, new or existing, in future
+        # Create parts for full work + its existing sections
+        for instrument in instruments:
+            part = Part.objects.get_or_create(written_for=instrument, musical_work=work)
+            part_object = Part.objects.get(written_for=instrument, musical_work=work)
+            work.parts.add(part_object)
+            for section in work.sections.all():
+                part = Part.objects.get_or_create(written_for=instrument, section=section)
+                part_object = Part.objects.get(written_for=instrument, section=section)
+                section.parts.add(part_object)
+
         # Create contributions
-        for form in contribution_forms:
-            person_given_name = form.cleaned_data['person_given_name']
-            person_surname = form.cleaned_data['person_surname']
-            range_date_birth = form.cleaned_data['person_range_date_birth']
-            range_date_death = form.cleaned_data['person_range_date_death']
-            role = form.cleaned_data['role']
-            certainty = form.cleaned_data['certainty_of_attribution']
-            location = form.cleaned_data['location']
-            date = form.cleaned_data['date']
-            if date:
-                year_from = form.cleaned_data['date'].lower
-                if year_from:
-                    date_from = datetime.date(year_from, 1, 1)
+        for contribution_form in contribution_forms:
+            contribution_form_idx = 0
+            while True:
+                person = contribution_form.cleaned_data.get(f'person_from_db_{contribution_form_idx}')
+                person_given_name = contribution_form.cleaned_data.get(f'person_given_name_{contribution_form_idx}')
+                if not person and not person_given_name:
+                    break # Invalid form
+                elif form.cleaned_data.get(f'person_in_database_{contribution_form_idx}'):
+                    person = person.first()
                 else:
-                    date_from = None
-                year_to = form.cleaned_data['date'].upper
-                if year_to:
-                    date_to = datetime.date(year_to, 2, 2)
-                else:
-                    date_to = None
-            else:
-                date_from, date_to = None, None
+                    try:
+                        person_surname = contribution_form.cleaned_data.get(f'person_surname_{contribution_form_idx}')
+                        person, created = Person.objects.get_or_create(
+                                        given_name=person_given_name,
+                                        surname=person_surname)    
+                        range_date_birth = contribution_form.cleaned_data.get(f'person_range_date_birth_{contribution_form_idx}')
+                        if not range_date_birth:
+                            birth_date_from, birth_date_to = None, None
+                        else:
+                            birth_date_from, birth_date_to = range_date_birth.lower, range_date_birth.upper
+                        range_date_death = contribution_form.cleaned_data.get(f'person_range_date_death_{contribution_form_idx}')
+                        if not range_date_death:
+                            death_date_from, death_date_to = None, None
+                        else:
+                            death_date_from, death_date_to = range_date_death.lower, range_date_death.upper
+                        person.birth_date_range_year_only = (birth_date_from, birth_date_to)
+                        person.death_date_range_year_only = (death_date_from, death_date_to)
+                        person.save() 
+                    except ValidationError as e:
+                        print(f'Validation error {e}')
+                        contribution_form_idx = contribution_form_idx+1
+                        continue                    
+        
+                role = contribution_form.cleaned_data.get(f'role_{contribution_form_idx}')
+                certainty = contribution_form.cleaned_data.get(f'certainty_of_attribution_{contribution_form_idx}')
+                location = contribution_form.cleaned_data.get(f'location_{contribution_form_idx}')
+                date = (contribution_form.cleaned_data.get(f'date_{contribution_form_idx}').lower, contribution_form.cleaned_data.get(f'date_{contribution_form_idx}').upper) if contribution_form.cleaned_data.get(f'date_{contribution_form_idx}') else None
+                
+                contribution = ContributionMusicalWork(person=person,
+                                            role=role,
+                                            certainty_of_attribution=certainty,
+                                            date_range_year_only=date,
+                                            location=location,
+                                            contributed_to_work=work)
+                try:
+                    contribution.save()
+                except ValidationError as e:
+                    self.form_invalid(form, contribution_forms, e)
+                print("Created new contribution")
+                contribution_form_idx += 1
 
-            person, created = Person.objects.get_or_create(
-                                                given_name=person_given_name,
-                                                surname=person_surname)
-            if range_date_birth:
-                birth_year_from = form.cleaned_data[
-                                    'person_range_date_birth'].lower
-                if birth_year_from:
-                    birth_date_from = datetime.date(birth_year_from, 1, 1)
-                else:
-                    birth_date_from = None
-                birth_year_to = form.cleaned_data[
-                                    'person_range_date_birth'].upper
-                if birth_year_to:
-                    birth_date_to = datetime.date(birth_year_to, 2, 2)
-                else:
-                    birth_date_to = None
-            else:
-                birth_date_to, birth_date_from = None, None
-
-            if range_date_death:
-                death_year_from = form.cleaned_data[
-                                    'person_range_date_death'].lower
-                if death_year_from:
-                    death_date_from = datetime.date(death_year_from, 1, 1)
-                else:
-                    death_date_from = None
-                death_year_to = form.cleaned_data[
-                                    'person_range_date_death'].upper
-                if death_year_to:
-                    death_date_to = datetime.date(death_year_to, 2, 2)
-                else:
-                    death_date_to = None
-            else:
-                death_date_from, death_date_to = None, None
-
-            person.range_date_birth = (birth_date_from, birth_date_to)
-            person.range_date_death = (death_date_from, death_date_to)
-            person.save()
-
-            contribution = ContributionMusicalWork(person=person,
-                                        role=role,
-                                        certainty_of_attribution=certainty,
-                                        date_range_year_only=date,#(date_from, death_date_from),
-                                        location=location,
-                                        contributed_to_work=work)
-            contribution.save()
-            request.session['work_id'] = work.id
+        request.session['work_id'] = work.id
         return HttpResponseRedirect('/file-create/')
 
-    def form_invalid(self, form, contribution_forms):
+    def form_invalid(self, form, contribution_forms, error_message=None):
         """
         Called if a form is invalid. Re-renders the context data with the
         data-filled forms and errors.
         """
+        print('Invalid form. Redirecting...')
+        print(form.errors)
+        if error_message is None:
+            error_message = "Please correct the form before resubmitting. All fields marked with * are required, unless the field is grayed out. For date ranges, if the date is known, you may enter it in a single box."
         return self.render_to_response(
-            self.get_context_data(form=form,
-                                  contribution_forms=contribution_forms))
+            self.get_context_data(error_message=error_message,
+                                  form=form,
+                                  contribution_form=contribution_forms))
+    


### PR DESCRIPTION
There were many problems with the contributor form and this workaround should sort them out. The ContributorForm lets  you add information about a contributor to a MusicalWork, and there can be multiple contributors per work. Duplicating the form was not working properly; this workaround manually defines 3 copies of the same widgets. A JavaScript function manages adding a set of contributor form widgets if the user needs it. Up to 3 ContributorForms can be added per form as of now. If more contributors are a part of a musical work, then user can always fill out another form for the same work.