### PR TITLE
Part file upload

### DIFF
--- a/database/admin.py
+++ b/database/admin.py
@@ -33,7 +33,7 @@ class MusicalWorkAdmin(admin.ModelAdmin):
 
 @admin.register(Section)
 class SectionAdmin(admin.ModelAdmin):
-    list_display = ("title","musical_work","parent_section","child_sections","source_instantiations","date_created","date_updated")
+    list_display = ("title","musical_work","parent_section","source_instantiations","date_created","date_updated")
     search_fields = ("title",)
     list_filter = ("date_created","date_updated")
 

--- a/database/templates/database/creation_form.html
+++ b/database/templates/database/creation_form.html
@@ -354,10 +354,7 @@
 
         var workCheckbox = $('#flexSwitchCheckDefault');
         workCheckbox.on('click', function() {
-            // var formElements = $('.work-container :input:not(#work-in-database :input)');
-            // var formLabels = $('.work-container label:not(#work-in-database label)');
             var checkboxChecked = $('#flexSwitchCheckDefault').is(':checked');
-
             if (checkboxChecked) {
                 formElements.prop('disabled', false);
                 formElements.show();

--- a/database/templates/database/creation_form.html
+++ b/database/templates/database/creation_form.html
@@ -32,8 +32,14 @@
                 {{ form.title_from_db.label_tag }}
                 {{ form.title_from_db_tooltips }}
             </div>
-            {{ form.title_from_db }}
-            <br><br>
+            {{ form.title_from_db }} <br><br>
+            <div class="form-check form-switch">
+                <input class="form-check-input" type="checkbox" value="" id="flexSwitchCheckDefault" name="work_not_in_database">
+                <label class="form-check-label" for="flexSwitchCheckDefault">
+                <p>Musical Work<b> not </b>in database</p>
+                </label>
+            </div>
+            <br>
             <div class="multiple-entry"> 
                 <div class="flex-row">
                     {{ form.variant_titles_from_db.label_tag }}
@@ -58,13 +64,8 @@
                 </div>
             </div>
             <br>
-            <div class="form-check form-switch">
-                <input class="form-check-input" type="checkbox" value="" id="flexSwitchCheckDefault" name="work_not_in_database">
-                <label class="form-check-label" for="flexSwitchCheckDefault">
-                <p>Musical Work<b> not </b>in database</p>
-                </label>
-            </div>
         </div>
+        <h4 id="new-musical-work-title">New Musical Work:</h4>
         {{ form.title.label_tag }}
         {{ form.title }}
         <br>
@@ -339,11 +340,13 @@
         for (var i = 1; i < 7; i++) {
             inputs[i].disabled = true;
         }
-
-        var formElements = $('.work-container :input:not(#work-in-database :input)');
+        
+        var inDatabaseFormElements = $('#work-in-database :input:not(.form-check-input)');
+        var formElements = $('.work-container :input:not(#work-in-database :input), #new-musical-work-title');
         var formLabels = $('.work-container label:not(#work-in-database label)');
         formLabels.hide();
         formElements.prop('disabled', true);
+        inDatabaseFormElements.prop('disabled', false);
         formElements.hide();
         
         var addNewInputs = $('.autocomplete-add :input');
@@ -351,18 +354,20 @@
 
         var workCheckbox = $('#flexSwitchCheckDefault');
         workCheckbox.on('click', function() {
-            var formElements = $('.work-container :input:not(#work-in-database :input)');
-            var formLabels = $('.work-container label:not(#work-in-database label)');
+            // var formElements = $('.work-container :input:not(#work-in-database :input)');
+            // var formLabels = $('.work-container label:not(#work-in-database label)');
             var checkboxChecked = $('#flexSwitchCheckDefault').is(':checked');
 
             if (checkboxChecked) {
                 formElements.prop('disabled', false);
                 formElements.show();
                 formLabels.show();
+                inDatabaseFormElements.prop('disabled', true);
             } else {
                 formElements.prop('disabled', true);
                 formElements.hide();
                 formLabels.hide();
+                inDatabaseFormElements.prop('disabled', false);
             }
         });
 

--- a/database/views/creation_view.py
+++ b/database/views/creation_view.py
@@ -149,14 +149,9 @@ class CreationView(FormView):
             section.ordering = int(count)
             section.save()
             work.sections.add(section)
-            # Create parts for each new section
-            for instrument in instruments:
-                part = Part.objects.get_or_create(written_for=instrument, section=section)
-                part_object = Part.objects.get(written_for=instrument, section=section)
-                section.parts.add(part_object)
 
         # TODO Can add feature to pick if part for full work or for certain section, new or existing, in future
-        # Create parts for full work + its existing sections
+        # Create parts for full work + its sections
         for instrument in instruments:
             part = Part.objects.get_or_create(written_for=instrument, musical_work=work)
             part_object = Part.objects.get(written_for=instrument, musical_work=work)

--- a/database/views/file_creation_view.py
+++ b/database/views/file_creation_view.py
@@ -34,7 +34,12 @@ class FileCreationView(FormView):
         work = work_queryset[0]
         sections = work.sections.all()
         parts = work.parts.all()
-
+        if parts:
+            for section in sections:
+                print(section)
+                print(section.parts)
+                parts.union(section.parts.all())
+        print(parts)
         # Here I am defining new classes dynamically.
         # It seems strange but I need to do this because the fields of a
         # form are class instances. We need a ModelChoiceField with a
@@ -97,6 +102,9 @@ class FileCreationView(FormView):
             work = work_queryset[0]
             sections = work.sections.all()
             parts = work.parts
+            if parts:
+                for section in sections:
+                    parts.append(section.parts)
 
             WorkFormSet = formset_factory(FileForm)
             work_formset = WorkFormSet(request.POST,

--- a/database/views/file_creation_view.py
+++ b/database/views/file_creation_view.py
@@ -139,8 +139,8 @@ class FileCreationView(FormView):
             (part_formset is None or part_formset.is_valid()) and
             (child_source_form.is_valid()) and 
             (parent_source_form.is_valid() or parent_source_form is None)) or \
-            (request.POST.get('work-0-file') == '' and request.POST.get('section-0-file') == ''):
-            if request.POST.get('work-0-file') == '' and request.POST.get('section-0-file') == '':
+            (request.POST.get('work-0-file') == '' and request.POST.get('section-0-file') == '' and request.POST.get('part-0-file') == ''):
+            if request.POST.get('work-0-file') == '' and request.POST.get('section-0-file') == '' and request.POST.get('part-0-file') == '':
                 return self.form_empty(work)
             
             return self.form_valid(work_formset, section_formset, part_formset,
@@ -247,7 +247,8 @@ class FileCreationView(FormView):
                     try:
                         instantiation = SourceInstantiation(source=child_source)
                         instantiation.save()
-                        instantiation.sections.set([section])
+                        section_object = Section.objects.get(pk=section.id)
+                        instantiation.sections.set([section_object])
                         instantiation.save()
                     except ValidationError as e:
                         print(f'source instance information not given: {e}')
@@ -285,7 +286,8 @@ class FileCreationView(FormView):
                     try:
                         instantiation = SourceInstantiation(source=child_source)
                         instantiation.save()
-                        instantiation.parts.set([part])
+                        part_object = Part.objects.get(pk=part.id)
+                        instantiation.parts.set([part_object])
                         instantiation.save()
                     except ValidationError as e:
                         print(f'part instance information not given: {e}')


### PR DESCRIPTION
File upload associated to part fix - files can be added to parts associated to the musical work or to a specific section. User can select from all parts for a given work.
Also rearranges frontend slightly according to Cory's suggestions to make logic of selecting musical work from database vs. creating a new one easier to understand. 
(Also has a quick fix for a bug in the admin page where one column was passed multiple values)