### PR TITLE
Frontend edits

### DIFF
--- a/database/templates/database/base.html
+++ b/database/templates/database/base.html
@@ -161,7 +161,7 @@
                 <a class="flex-sm-fill text-sm-center nav-link" href="http://elvisproject.ca" target="_blank">ELVIS
                     Project</a>
                 <a class="flex-sm-fill text-sm-center nav-link" href="https://github.com/ELVIS-Project/simssadb"
-                    target="_blank">GitHub Repo</a>
+                    target="_blank">SIMSSA DB GitHub Repo</a>
             </nav>
         </div>
         <br>

--- a/database/templates/database/creation_form.html
+++ b/database/templates/database/creation_form.html
@@ -110,20 +110,20 @@
                         <input class="form-check-input check-contributor" id="check-contributor_0" type="checkbox" value="" name="person_not_in_database_0">
                         <label class="form-check-label" for="check-contributor_0">Person is not in database</label>
                     </div>
-                    <div class="contribution-form-field flex-row">
+                    <div class="contribution-form-field flex-row new-contributor-elements">
                         {{ contribution_form.person_given_name_0.label_tag }}
                         {{ contribution_form.person_given_name_0 }}
                     </div>
-                    <div class="contribution-form-field flex-row">
+                    <div class="contribution-form-field flex-row new-contributor-elements">
                         {{ contribution_form.person_surname_0.label_tag }}
                         {{ contribution_form.person_surname_0 }}
                     </div>
-                    <div class="contribution-form-field flex-row">
+                    <div class="contribution-form-field flex-row new-contributor-elements">
                         {{ contribution_form.person_range_date_birth_0.label_tag }}
                         {{ contribution_form.person_range_date_birth_0 }}
                         {{ contribution_form.birth_info }}
                     </div>
-                    <div class="contribution-form-field flex-row">
+                    <div class="contribution-form-field flex-row new-contributor-elements">
                         {{ contribution_form.person_range_date_death_0.label_tag }}
                         {{ contribution_form.person_range_date_death_0 }}
                         {{ contribution_form.death_info }}
@@ -256,7 +256,6 @@
         new_form.find('span[data-select2-id]').attr('data-select2-id', form_idx);
         
         // Initialize new form inputs to disabled
-        new_form.find(':input').slice(2,8).prop('disabled', true);
         var locationInput = $('#add-location-input_' + form_idx);
         locationInput.prop('disabled', true);
         
@@ -264,7 +263,14 @@
         new_form.find('.check-contributor').on('change', function() {
             var cur_form = $(this).closest('.contribution-form');
             var isChecked = $(this).prop('checked');
-            cur_form.find(':input').slice(3,9).prop('disabled', !isChecked);
+            var new_contributor_elements = cur_form.find('.new-contributor-elements');
+            cur_form.find('select:first').prop('disabled', isChecked);
+            new_contributor_elements.prop('disabled', !isChecked);
+            if (isChecked) {
+                new_contributor_elements.show();
+            } else {
+                new_contributor_elements.hide();
+            }
         });
         new_form.find('#check-location_'+form_idx).on('change', function() {
             var isChecked = $(this).prop('checked');
@@ -334,19 +340,16 @@
 
     // Disable form if checkbox indicating musical work already exists in the database is selected
     $(document).ready(function() {
-        // Initialize all contributor form elements relating to person to disabled 
-        var form = document.getElementById('contribution-form_0');
-        var inputs = form.getElementsByTagName('input');
-        for (var i = 1; i < 7; i++) {
-            inputs[i].disabled = true;
-        }
-        
+        // Initialize all form elements to create a new person/work to disabled and hidden
+        var new_contributor_elements = $('.new-contributor-elements');
+        new_contributor_elements.prop('disabled', true);
+        new_contributor_elements.hide();
         var inDatabaseFormElements = $('#work-in-database :input:not(.form-check-input)');
-        var formElements = $('.work-container :input:not(#work-in-database :input), #new-musical-work-title');
+        inDatabaseFormElements.prop('disabled', false);
         var formLabels = $('.work-container label:not(#work-in-database label)');
         formLabels.hide();
+        var formElements = $('.work-container :input:not(#work-in-database :input), #new-musical-work-title');
         formElements.prop('disabled', true);
-        inDatabaseFormElements.prop('disabled', false);
         formElements.hide();
         
         var addNewInputs = $('.autocomplete-add :input');
@@ -395,7 +398,14 @@
         $('#form_set').find('#check-contributor_' + form_idx).on('change', function() {
             var cur_form = $(this).closest('.contribution-form');
             var isChecked = $(this).prop('checked');
-            cur_form.find(':input').slice(2,8).prop('disabled', !isChecked);
+            cur_form.find('select:first').prop('disabled', isChecked);
+            var new_contributor_elements = cur_form.find('.new-contributor-elements');
+            new_contributor_elements.prop('disabled', !isChecked);
+            if (isChecked) {
+                new_contributor_elements.show();
+            } else {
+                new_contributor_elements.hide();
+            }        
         });
 
     });

--- a/database/templates/database/creation_form.html
+++ b/database/templates/database/creation_form.html
@@ -21,8 +21,8 @@
     <h3> Title </h3>
     <div id='work_form'>
     <p>
-        What is the title of the work? If it is already in the database, select it. Otherwise, enter it below.
-        Click the green button to add variant titles or nicknames.
+        Check if the work is already in the database. If so, then select it. If not, then check the 
+        "Musical Work not in database" checkbox below and enter the title in the field that appears.
         Please include opus number or catalogue numbers if applicable (e.g., 
         Op. 55, D960, BWV 202).
     </p>
@@ -89,7 +89,7 @@
     </div>
     <br>
     <div class="flex-row">
-        <h3> Contributions </h3> {{ form.contribution_tooltips }} 
+        <h3> Contributors </h3> {{ form.contribution_tooltips }} 
     </div>
     {{ contribution_form.management_form }}
         <div id="form_set">

--- a/database/templates/database/home.html
+++ b/database/templates/database/home.html
@@ -30,12 +30,11 @@
             <div class="col-sm-4">
                 <h2 class="media-heading">
                     <a href="{% url 'cart' %}">
-                        Download
+                        Download Cart
                     </a>
                 </h2>
                 <p>
-                    Download the
-                    files you need.
+                    Download or remove files added to your cart.
                 </p>
             </div>
             <div class="col-sm-4">

--- a/database/templates/database/musicalwork_detail.html
+++ b/database/templates/database/musicalwork_detail.html
@@ -57,16 +57,16 @@
 <div class="container">
     <ul class="nav nav-tabs" id="tabs" role="tablist">
         <li class="nav-item">
-            <a class="nav-link active" id="sections-tab" data-toggle="tab" href="#sections" role="tab" aria-controls="sections" aria-selected="true">Sections</a>
+            <a class="nav-link active" id="files-tab" data-toggle="tab" href="#files" role="tab" aria-controls="files" aria-selected="true">Files</a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" id="sections-tab" data-toggle="tab" href="#sections" role="tab" aria-controls="sections" aria-selected="false">Sections</a>
         </li>
         <li class="nav-item">
             <a class="nav-link" id="parts-tab" data-toggle="tab" href="#parts" role="tab" aria-controls="parts" aria-selected="false">Parts</a>
         </li>
         <li class="nav-item">
             <a class="nav-link" id="related-works-tab" data-toggle="tab" href="#related-works" role="tab" aria-controls="related-works" aria-selected="false">Related Works</a>
-        </li>
-        <li class="nav-item">
-            <a class="nav-link" id="files-tab" data-toggle="tab" href="#files" role="tab" aria-controls="files" aria-selected="false">Files</a>
         </li>
     </ul>
     <div class="tab-content" id="tabs-content">

--- a/database/templates/database/section_detail.html
+++ b/database/templates/database/section_detail.html
@@ -44,17 +44,17 @@
 <div class="container">
     <ul class="nav nav-tabs" id="tabs" role="tablist">
         <li class="nav-item">
+            <a class="nav-link active" id="files-tab" data-toggle="tab" href="#files" role="tab" aria-controls="files" aria-selected="false">Files</a>
+        </li>
+        <li class="nav-item">
             <a class="nav-link" id="parts-tab" data-toggle="tab" href="#parts" role="tab" aria-controls="parts" aria-selected="false">Parts</a>
         </li>
-        <li class="nav-item">
-            <a class="nav-link" id="files-tab" data-toggle="tab" href="#files" role="tab" aria-controls="files" aria-selected="false">Files</a>
-        </li>
-        <li class="nav-item">
-            <a class="nav-link active" id="parent-sections-tab" data-toggle="tab" href="#parent-sections" role="tab" aria-controls="parent-sections" aria-selected="true">Parent Sections</a>
+        <!-- <li class="nav-item">
+            <a class="nav-link" id="parent-sections-tab" data-toggle="tab" href="#parent-sections" role="tab" aria-controls="parent-sections" aria-selected="true">Parent Sections</a>
         </li>
         <li class="nav-item">
             <a class="nav-link" id="child-sections-tab" data-toggle="tab" href="#child-sections" role="tab" aria-controls="child-sections" aria-selected="false">Child Sections</a>
-        </li>
+        </li> -->
         <li class="nav-item">
             <a class="nav-link" id="related-sections-tab" data-toggle="tab" href="#related-sections" role="tab" aria-controls="related-sections" aria-selected="false">Related Sections</a>
         </li>


### PR DESCRIPTION
Quick frontend fixes. Title changes and description edits; changing the order of tabs in musical work detail pages, changing the default tab open; and hiding the input elements to create a new contributor unless the 'contributor not in database' checkbox is checked.