### PR TITLE
Upload for demo

### DIFF
--- a/database/templates/database/file_creation_form.html
+++ b/database/templates/database/file_creation_form.html
@@ -20,6 +20,13 @@
         #warning {
             color: rgb(0, 19, 103);
         }
+        #add_more_work, #add_more_section, #add_more_part {
+            margin-bottom: 5vh;
+        }
+        .btn {
+            margin-top: 1vh;
+        }
+
     </style>
 <form method="post" enctype="multipart/form-data">
     {% csrf_token %}
@@ -39,11 +46,9 @@
             <p> Please attach files below that represent the whole musical work (i.e., all movements or sections).</p>
             {% for form in work_formset %}
                 {{ form.as_p }}
-                <br>
             {% endfor %}
         </div>
         <input input class="btn btn-success btn-sm" type="button" id="add_more_work" value="+">
-        <br><br>
         {% endif %}
 
         {% if section_formset %}
@@ -53,11 +58,9 @@
             <p> Please attach files that represent individual sections below. Choose the section from the dropdown menu.</p>
             {% for form in section_formset %}
                 {{ form.as_p }}
-                <br>
             {% endfor %}
         </div>
         <input input class="btn btn-success btn-sm" type="button" id="add_more_section" value="+">
-        <br>
         {% endif %}
 
         {% if part_formset %}
@@ -67,14 +70,10 @@
             <p> Please attach individual parts to the appropriate voice or instrument below.</p>
             {% for form in part_formset %}
                 {{ form.as_p }}
-                <br>
             {% endfor %}
             </div>
         <input input class="btn btn-success btn-sm" type="button" id="add_more_part" value="+">
-        <br>
         {% endif %}
-    <br>
-    <br>
     <div id="sources">
         <h3>Where did these files come from?</h3>
         <p>

--- a/database/views/creation_view.py
+++ b/database/views/creation_view.py
@@ -42,6 +42,17 @@ class CreationView(FormView):
         validity.
         """
         # FOR DEMO
+        request.session['work_id'] = 108
+        post_data = request.POST.copy()
+        title = request.POST.get('title_from_db')
+        if not title == None:
+            post_data['title_from_db'] = [title]
+        request.POST = post_data
+        form = WorkInfoForm(request.POST)
+        if form.is_valid():
+            work = form.cleaned_data['title_from_db'].first()
+            if work:
+                request.session['work_id'] = work.id
         return HttpResponseRedirect('/file-create/')
     
         # The form expects a list of titles and people for each autocomplete widget, 

--- a/database/views/file_creation_view.py
+++ b/database/views/file_creation_view.py
@@ -93,6 +93,9 @@ class FileCreationView(FormView):
         validity.
         """
         # FOR DEMO
+        work_id = request.session['work_id']
+        if work_id != 108: # 108 is default for demo if User does not select a musical work
+            return HttpResponseRedirect('/musicalworks/' + str(work_id))
         return HttpResponseRedirect('/musicalworks/')
     
         work_id = request.session['work_id']


### PR DESCRIPTION
Fix for bug where form's musical work id was empty. If no musical work from database is selected, default to 108 (random, just because 108 has multiple sections). If it is 108, assume no work was selected and show the full musical works list page.
Also has a small change for spacing in the second page of the form