### PR TITLE
if no work selected, default to random work for demo purposes:

### DIFF
--- a/database/views/file_creation_view.py
+++ b/database/views/file_creation_view.py
@@ -26,7 +26,13 @@ class FileCreationView(FormView):
         Handles GET requests and instantiates blank versions of the form
         and the formsets.
         """
-        work_id = request.session['work_id']
+        # FOR DEMO
+        try:
+            work_id = request.session['work_id']
+        except KeyError:
+            request.session['work_id'] = 108 # default for demo purposes only.
+            work_id = 108
+
         work_queryset = MusicalWork.objects.filter(pk=work_id)
         if not work_queryset.exists(): 
             raise Exception


### PR DESCRIPTION
Quick fix for KeyError. Make sure that even if no work is selected, all pages can be viewed for demo purposes - so default to random work (I picked 108).